### PR TITLE
Add support for grayscale grid

### DIFF
--- a/lib/_grid.lua
+++ b/lib/_grid.lua
@@ -156,6 +156,7 @@ end
 
 function _grid:led_signals()
   local level = page.active_page == 3 and menu.selected_item == 1 and 10 or 2
+  if parameters.is_grayscale_on then level = 15 end
   for k,v in pairs(keeper.signals) do
     if v.generation <= counters.music_generation then
       g:led(v.x, v.y, level)
@@ -224,8 +225,10 @@ function _grid:led_signal_and_cell_collision()
 end
 
 function _grid:led_cells()
+  local level = 5
+  if parameters.is_grayscale_on then level = 15 end
   for k,v in pairs(keeper.cells) do
-    g:led(v.x, v.y, 5)
+    g:led(v.x, v.y, level)
   end
 end
 

--- a/lib/parameters.lua
+++ b/lib/parameters.lua
@@ -32,6 +32,10 @@ function parameters.init()
   params:add_option("splash_screen", "SPLASH SCREEN", {"ENABLED", "DISABLED"})
   params:set_action("splash_screen", function(index) parameters.is_splash_screen_on = index == 1 and true or false end)
 
+  parameters.is_grayscale_on = false
+  params:add_option("grayscale", "GRAYSCALE", {"ENABLED", "DISABLED"})
+  params:set_action("grayscale", function(index) parameters.is_grayscale_on = index == 1 and true or false end)
+
   params:add_separator("")
   params:add_separator("KUDZU MANAGEMENT")
 


### PR DESCRIPTION
This adds support for grayscale grid as a configuration option.

I do not know if a grayscale grid can be detected through the `Grid` class. I did not see anything in the documentation indicating it was possible.

This is my first manipulation of parameter sets but I assume this will not break existing saved psets.

Tested on a grid 64 40h. I do not have a varibright device to test on.